### PR TITLE
Query parameters

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,23 +19,59 @@ export default {
   data() {
     return {
       isTransitionActive: false,
-      slogan: 'Generate your slogan',
-      sloganIndices: [],
-      config: {},
+      // slogan: 'Generate your slogan',
+      // sloganIndices: [],
+      // config: {},
     };
+  },
+  computed: {
+    slogan() {
+      if (this.sloganIndices.length) {
+        return Generator.loadSlogan(this.sloganIndices);
+      }
+      return 'Generate your slogan';
+    },
+    sloganIndices() {
+      try {
+        const indices = JSON.parse(this.$route.query.result);
+        return indices;
+      } catch (e) {
+        return [];
+      }
+    },
+    config() {
+      try {
+        const config = JSON.parse(this.$route.query.config);
+        return config;
+      } catch (e) {
+        return {};
+      }
+    },
   },
   methods: {
     setTransition(isActive = true) {
       this.isTransitionActive = isActive;
     },
     receiveConfigChange(config) {
-      this.config = Object.assign(this.config, config, this.config);
-      console.log(this.config);
+      this.$router.replace({
+        query: {
+          ...this.$route.query,
+          config: JSON.stringify(config),
+        },
+      });
+      // this.config = Object.assign(this.config, config, this.config);
+      // console.log(this.config);
     },
     generateSlogan() {
-      const { text, indices } = Generator.generateSlogan(this.config);
-      this.slogan = text;
-      this.sloganIndices = indices;
+      const { indices } = Generator.generateSlogan(this.config);
+      this.$router.replace({
+        query: {
+          ...this.$route.query,
+          result: JSON.stringify(indices),
+        },
+      });
+      // this.slogan = text;
+      // this.sloganIndices = indices;
     },
   },
 };

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,9 +19,6 @@ export default {
   data() {
     return {
       isTransitionActive: false,
-      // slogan: 'Generate your slogan',
-      // sloganIndices: [],
-      // config: {},
     };
   },
   computed: {
@@ -59,8 +56,6 @@ export default {
           config: JSON.stringify(config),
         },
       });
-      // this.config = Object.assign(this.config, config, this.config);
-      // console.log(this.config);
     },
     generateSlogan() {
       const { indices } = Generator.generateSlogan(this.config);
@@ -70,8 +65,6 @@ export default {
           result: JSON.stringify(indices),
         },
       });
-      // this.slogan = text;
-      // this.sloganIndices = indices;
     },
   },
 };

--- a/src/components/Customize.vue
+++ b/src/components/Customize.vue
@@ -11,7 +11,6 @@
         <router-link :to="{ name: 'Main', query: $route.query }" class="delete is-large" slot="right">
           Back
         </router-link>
-        <!-- <button class="delete is-large" slot="right" @click="$router.go(-1)">Back</button> -->
       </Bar>
       <section class="section">
         <div class="container">

--- a/src/components/Customize.vue
+++ b/src/components/Customize.vue
@@ -8,7 +8,10 @@
     <div class="is-overlay">
       <Bar class="is-light">
         <h1 class="title">Customize</h1>
-        <button class="delete is-large" slot="right" @click="$router.go(-1)">Back</button>
+        <router-link :to="{ name: 'Main', query: $route.query }" class="delete is-large" slot="right">
+          Back
+        </router-link>
+        <!-- <button class="delete is-large" slot="right" @click="$router.go(-1)">Back</button> -->
       </Bar>
       <section class="section">
         <div class="container">

--- a/src/components/CustomizePanel.vue
+++ b/src/components/CustomizePanel.vue
@@ -8,11 +8,11 @@
       </header>
       <div class="card-content">
         <b-field class="min-max-tokens">
-          <input type="number" min="3" max="12" :value="minTokens" 
+          <input type="number" min="3" max="12" :value="minTokens"
           @change="handleChangeMin"
           @input="handleChangeMin">
           <span>-</span>
-          <input type="number" min="3" max="12" :value="maxTokens" 
+          <input type="number" min="3" max="12" :value="maxTokens"
           @change="handleChangeMax"
           @input="handleChangeMax">
         </b-field>
@@ -26,7 +26,7 @@
       </header>
       <div class="card-content">
         <b-field>
-          <b-taginput 
+          <b-taginput
             @input="changeExclude"
             @typing="getFilteredTags"
             autocomplete :data="filteredTags"
@@ -42,7 +42,7 @@
       </header>
       <div class="card-content">
         <b-field>
-          <b-taginput 
+          <b-taginput
             @input="changeInclude"
             @typing="getFilteredTags"
             autocomplete :data="filteredTags"
@@ -71,50 +71,50 @@ export default {
     handleChangeMin(e) {
       const value = parseInt(e.target.value, 10);
 
-      if(value >= 12) {
+      if (value >= 12) {
         e.preventDefault();
         e.target.value = 12;
       }
 
-      if(value > this.maxTokens) {
+      if (value > this.maxTokens) {
         e.preventDefault();
         e.target.value = this.maxTokens;
       }
       this.minTokens = e.target.value;
-      this.$emit('change-config', {minTokens: parseInt(e.target.value)});
+      this.$emit('change-config', { minTokens: parseInt(e.target.value, 10) });
     },
     handleChangeMax(e) {
       const value = parseInt(e.target.value, 10);
 
-      if(value >= 12) {
+      if (value >= 12) {
         e.preventDefault();
         e.target.value = 12;
       }
 
-      if(value < this.minTokens) {
+      if (value < this.minTokens) {
         e.preventDefault();
         e.target.value = this.minTokens;
       }
       this.maxTokens = e.target.value;
-      this.$emit('change-config', {maxTokens: parseInt(e.target.value)});
+      this.$emit('change-config', { maxTokens: parseInt(e.target.value, 10) });
     },
     changeInclude(include) {
       this.include = include;
-      this.$emit('change-config', {include});
+      this.$emit('change-config', { include });
     },
     changeExclude(exclude) {
       this.exclude = exclude;
-      this.$emit('change-config', {exclude});
+      this.$emit('change-config', { exclude });
     },
     getFilteredTags(text) {
       this.filteredTags = tokens.filter(
-        (option) => {
-          return this.include.indexOf(option) == -1 && this.exclude.indexOf(option) == -1 && option.indexOf(text) >= 0
-        }
-      )
-    }
-  }
-}
+        option => this.include.indexOf(option) === -1 &&
+        this.exclude.indexOf(option) === -1 &&
+        option.indexOf(text) >= 0,
+      );
+    },
+  },
+};
 </script>
 
 <style scoped>

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -14,7 +14,7 @@
         />
       </transition>
       <transition name="fade" mode="out-in" slot="foot">
-        <router-link :to="{ name: 'Customize' }"
+        <router-link :to="{ name: 'Customize', query: $route.query }"
           class="button is-light is-radiusless is-fullwidth"
           v-if="$route.name === 'Main'"
         >

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -2,7 +2,7 @@
   <nav class="navbar">
     <div class="container">
       <div class="navbar-brand">
-        <router-link :to="{ name: 'Main' }" class="navbar-item has-text-weight-bold is-unselectable">
+        <router-link :to="{ name: 'Main', query: $route.query }" class="navbar-item has-text-weight-bold is-unselectable">
           <span class="has-text-dark is-size-4">SloGen</span><sup class="is-size-6 wandek"><em>wandek</em></sup>
         </router-link>
 
@@ -14,7 +14,7 @@
       </div>
       <div class="navbar-menu" :class="{ 'is-active': isMenuActive }">
         <div class="navbar-end">
-          <router-link :to="{ name: 'FunFacts' }" class="navbar-item">
+          <router-link :to="{ name: 'FunFacts', query: $route.query }" class="navbar-item">
             Fun Facts
           </router-link>
           <a class="navbar-item" href="https://github.com/blead/slogen" target="_blank">

--- a/src/generator/index.js
+++ b/src/generator/index.js
@@ -15,11 +15,11 @@ const randomInt = (bound, bound2) => {
 
 /* eslint-disable no-unused-vars */
 const generateSlogan = (config = {}) => { /* eslint-enable */
-  console.log('generateSlogan', config);
+  // console.log('generateSlogan', config);
   const minTokens = config.minTokens || 3;
   const maxTokens = config.maxTokens || 6;
   const expectedLength = randomInt(minTokens, maxTokens + 1);
-  console.log(minTokens, maxTokens, expectedLength);
+  // console.log(minTokens, maxTokens, expectedLength);
   const result = [];
   const queryToken = tokens.slice();
   if (config.exclude !== undefined) {


### PR DESCRIPTION
- Use query parameters as source of truth for `slogan`, `sloganIndices`, and `config`.
- The 3 mentioned properties become computed properties instead.
- All navigation links are modified to retain query parameters.
- Fix code formatting again.